### PR TITLE
Corrected IntelliJ version to match the correct build number pattern

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ sourceCompatibility = 1.8
 group 'com.schibsted.protein'
 version buildVersion
 
-def intelliJVersion = 'IC-2018.1.6'
+def intelliJVersion = 'IC-182.4505.22'
 
 intellij {
     version intelliJVersion


### PR DESCRIPTION
## GitHub link
No link

## Description
Before publishing the latest version we've noticed that the version number does not match the correct build ranges admitted by the latest plugin publishing task

## How has this been tested?
Manually

## Screenshots
No Screens