### PR TITLE
[Issue #8] Now shows the modules from the current project active

### DIFF
--- a/src/main/java/protein/common/StorageUtils.java
+++ b/src/main/java/protein/common/StorageUtils.java
@@ -1,7 +1,10 @@
 package protein.common;
 
 import com.bugsnag.Bugsnag;
+import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.DataConstants;
 import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -9,7 +12,8 @@ import com.squareup.kotlinpoet.FileSpec;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
+import javax.swing.ListModel;
+import javax.swing.DefaultListModel;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -20,15 +24,15 @@ public class StorageUtils {
     @NotNull
     public static ListModel getFoldersList() {
         DefaultListModel listModel = new DefaultListModel();
-
-        VirtualFile[] contentRoots = ProjectRootManager.getInstance(ProjectManager.getInstance().getOpenProjects()[0]).getContentRoots();
+        Project currentProject = (Project)DataManager.getInstance().getDataContext().getData(DataConstants.PROJECT);
+        VirtualFile[] contentRoots = ProjectRootManager.getInstance(currentProject).getContentRoots();
         for (VirtualFile virtualFile : contentRoots) {
             if (virtualFile.isDirectory() && virtualFile.isWritable()) {
                 listModel.addElement(virtualFile.getName());
             }
         }
 
-        VirtualFile[] contentRootsFromAllModules = ProjectRootManager.getInstance(ProjectManager.getInstance().getOpenProjects()[0]).getContentRootsFromAllModules()[0].getChildren();
+        VirtualFile[] contentRootsFromAllModules = ProjectRootManager.getInstance(currentProject).getContentRootsFromAllModules()[0].getChildren();
         for (VirtualFile virtualFile : contentRootsFromAllModules) {
             if (virtualFile.isDirectory() && virtualFile.isWritable()) {
                 listModel.addElement(virtualFile.getName());

--- a/src/main/java/protein/common/StorageUtils.java
+++ b/src/main/java/protein/common/StorageUtils.java
@@ -25,17 +25,19 @@ public class StorageUtils {
     public static ListModel getFoldersList() {
         DefaultListModel listModel = new DefaultListModel();
         Project currentProject = (Project)DataManager.getInstance().getDataContext().getData(DataConstants.PROJECT);
-        VirtualFile[] contentRoots = ProjectRootManager.getInstance(currentProject).getContentRoots();
-        for (VirtualFile virtualFile : contentRoots) {
-            if (virtualFile.isDirectory() && virtualFile.isWritable()) {
-                listModel.addElement(virtualFile.getName());
+        if (currentProject != null) {
+            VirtualFile[] contentRoots = ProjectRootManager.getInstance(currentProject).getContentRoots();
+            for (VirtualFile virtualFile : contentRoots) {
+                if (virtualFile.isDirectory() && virtualFile.isWritable()) {
+                    listModel.addElement(virtualFile.getName());
+                }
             }
-        }
 
-        VirtualFile[] contentRootsFromAllModules = ProjectRootManager.getInstance(currentProject).getContentRootsFromAllModules()[0].getChildren();
-        for (VirtualFile virtualFile : contentRootsFromAllModules) {
-            if (virtualFile.isDirectory() && virtualFile.isWritable()) {
-                listModel.addElement(virtualFile.getName());
+            VirtualFile[] contentRootsFromAllModules = ProjectRootManager.getInstance(currentProject).getContentRootsFromAllModules()[0].getChildren();
+            for (VirtualFile virtualFile : contentRootsFromAllModules) {
+                if (virtualFile.isDirectory() && virtualFile.isWritable()) {
+                    listModel.addElement(virtualFile.getName());
+                }
             }
         }
         return listModel;


### PR DESCRIPTION
## GitHub link
Issue #8 

## Description
There was a problem when multiple project windows were open, it does not changed the context to load the modules of the current active project. Instead it loaded the first opened project modules.

## How has this been tested?
Manually

## Screenshots
No Screens