### PR TITLE
Removes `/` from the beginning of annotation paths

### DIFF
--- a/src/main/kotlin/protein/kotlinbuilders/KotlinApiBuilder.kt
+++ b/src/main/kotlin/protein/kotlinbuilders/KotlinApiBuilder.kt
@@ -216,16 +216,16 @@ class KotlinApiBuilder(
 
           val annotationSpec: AnnotationSpec = when {
             operation.key.name.contains(
-              "GET") -> AnnotationSpec.builder(GET::class).addMember("\"${path.key}\"").build()
+              "GET") -> AnnotationSpec.builder(GET::class).addMember("\"${path.key.removePrefix("/")}\"").build()
             operation.key.name.contains(
-              "POST") -> AnnotationSpec.builder(POST::class).addMember("\"${path.key}\"").build()
+              "POST") -> AnnotationSpec.builder(POST::class).addMember("\"${path.key.removePrefix("/")}\"").build()
             operation.key.name.contains(
-              "PUT") -> AnnotationSpec.builder(PUT::class).addMember("\"${path.key}\"").build()
+              "PUT") -> AnnotationSpec.builder(PUT::class).addMember("\"${path.key.removePrefix("/")}\"").build()
             operation.key.name.contains(
-              "PATCH") -> AnnotationSpec.builder(PATCH::class).addMember("\"${path.key}\"").build()
+              "PATCH") -> AnnotationSpec.builder(PATCH::class).addMember("\"${path.key.removePrefix("/")}\"").build()
             operation.key.name.contains(
-              "DELETE") -> AnnotationSpec.builder(DELETE::class).addMember("\"${path.key}\"").build()
-            else -> AnnotationSpec.builder(GET::class).addMember("\"${path.key}\"").build()
+              "DELETE") -> AnnotationSpec.builder(DELETE::class).addMember("\"${path.key.removePrefix("/")}\"").build()
+            else -> AnnotationSpec.builder(GET::class).addMember("\"${path.key.removePrefix("/")}\"").build()
           }
 
           try {

--- a/src/test/kotlin/KotlinApiBuilderShould.kt
+++ b/src/test/kotlin/KotlinApiBuilderShould.kt
@@ -58,7 +58,7 @@ class KotlinApiBuilderShould {
             "     *\n" +
             "     * @param Authorization Authorization\n" +
             "     */\n" +
-            "    @GET(\"/favorites\")\n" +
+            "    @GET(\"favorites\")\n" +
             "    fun getFavorites(): Single<GetFavoritesResponse>\n" +
             "\n" +
             "    /**\n" +
@@ -67,7 +67,7 @@ class KotlinApiBuilderShould {
             "     * @param adId adId\n" +
             "     * @param Authorization Authorization\n" +
             "     */\n" +
-            "    @PUT(\"/favorites/{adId}\")\n" +
+            "    @PUT(\"favorites/{adId}\")\n" +
             "    fun saveFavorite(@Path(\"adId\") adId: String): Completable\n" +
             "\n" +
             "    /**\n" +
@@ -76,7 +76,7 @@ class KotlinApiBuilderShould {
             "     * @param adId adId\n" +
             "     * @param Authorization Authorization\n" +
             "     */\n" +
-            "    @DELETE(\"/favorites/{adId}\")\n" +
+            "    @DELETE(\"favorites/{adId}\")\n" +
             "    fun deleteFavorite(@Path(\"adId\") adId: String): Completable\n" +
             "}\n",
         kotlinApiBuilder.getGeneratedApiInterfaceString())

--- a/src/test/kotlin/mocks/openstf_code_generated_mocks.kt
+++ b/src/test/kotlin/mocks/openstf_code_generated_mocks.kt
@@ -15,7 +15,7 @@ const val OPENSTF_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "    /**\n" +
   "     * User Profile\n" +
   "     */\n" +
-  "    @GET(\"/user\")\n" +
+  "    @GET(\"user\")\n" +
   "    fun getUser(): Single<UserResponse>\n" +
   "\n" +
   "    /**\n" +
@@ -23,7 +23,7 @@ const val OPENSTF_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param fields Fields query parameter takes a comma seperated list of fields. Only listed field will be return in response\n" +
   "     */\n" +
-  "    @GET(\"/user/devices\")\n" +
+  "    @GET(\"user/devices\")\n" +
   "    fun getUserDevices(@Query(\"fields\") fields: String?): Single<DeviceListResponse>\n" +
   "\n" +
   "    /**\n" +
@@ -31,7 +31,7 @@ const val OPENSTF_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param device Device to add\n" +
   "     */\n" +
-  "    @POST(\"/user/devices\")\n" +
+  "    @POST(\"user/devices\")\n" +
   "    fun addUserDevice(@Body device: AddUserDevicePayload): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -40,7 +40,7 @@ const val OPENSTF_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     * @param serial Device Serial\n" +
   "     * @param fields Fields query parameter takes a comma seperated list of fields. Only listed field will be return in response\n" +
   "     */\n" +
-  "    @GET(\"/user/devices/{serial}\")\n" +
+  "    @GET(\"user/devices/{serial}\")\n" +
   "    fun getUserDeviceBySerial(@Path(\"serial\") serial: String, @Query(\"fields\") fields: String?): Single<DeviceResponse>\n" +
   "\n" +
   "    /**\n" +
@@ -48,7 +48,7 @@ const val OPENSTF_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param serial Device Serial\n" +
   "     */\n" +
-  "    @DELETE(\"/user/devices/{serial}\")\n" +
+  "    @DELETE(\"user/devices/{serial}\")\n" +
   "    fun deleteUserDeviceBySerial(@Path(\"serial\") serial: String): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -56,7 +56,7 @@ const val OPENSTF_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param serial Device Serial\n" +
   "     */\n" +
-  "    @POST(\"/user/devices/{serial}/remoteConnect\")\n" +
+  "    @POST(\"user/devices/{serial}/remoteConnect\")\n" +
   "    fun remoteConnectUserDeviceBySerial(@Path(\"serial\") serial: String): Single<RemoteConnectUserDeviceResponse>\n" +
   "\n" +
   "    /**\n" +
@@ -64,13 +64,13 @@ const val OPENSTF_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param serial Device Serial\n" +
   "     */\n" +
-  "    @DELETE(\"/user/devices/{serial}/remoteConnect\")\n" +
+  "    @DELETE(\"user/devices/{serial}/remoteConnect\")\n" +
   "    fun remoteDisconnectUserDeviceBySerial(@Path(\"serial\") serial: String): Completable\n" +
   "\n" +
   "    /**\n" +
   "     * Access Tokens\n" +
   "     */\n" +
-  "    @GET(\"/user/accessTokens\")\n" +
+  "    @GET(\"user/accessTokens\")\n" +
   "    fun getUserAccessTokens(): Single<AccessTokensResponse>\n" +
   "\n" +
   "    /**\n" +
@@ -78,7 +78,7 @@ const val OPENSTF_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param fields Fields query parameter takes a comma seperated list of fields. Only listed field will be return in response\n" +
   "     */\n" +
-  "    @GET(\"/devices\")\n" +
+  "    @GET(\"devices\")\n" +
   "    fun getDevices(@Query(\"fields\") fields: String?): Single<DeviceListResponse>\n" +
   "\n" +
   "    /**\n" +
@@ -87,6 +87,6 @@ const val OPENSTF_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     * @param serial Device Serial\n" +
   "     * @param fields Fields query parameter takes a comma seperated list of fields. Only listed field will be return in response\n" +
   "     */\n" +
-  "    @GET(\"/devices/{serial}\")\n" +
+  "    @GET(\"devices/{serial}\")\n" +
   "    fun getDeviceBySerial(@Path(\"serial\") serial: String, @Query(\"fields\") fields: String?): Single<DeviceResponse>\n" +
   "}\n"

--- a/src/test/kotlin/mocks/pet_store_code_generated_mocks.kt
+++ b/src/test/kotlin/mocks/pet_store_code_generated_mocks.kt
@@ -19,7 +19,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param body Pet object that needs to be added to the store\n" +
   "     */\n" +
-  "    @PUT(\"/pet\")\n" +
+  "    @PUT(\"pet\")\n" +
   "    fun updatePet(@Body body: Pet): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -27,7 +27,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param body Pet object that needs to be added to the store\n" +
   "     */\n" +
-  "    @POST(\"/pet\")\n" +
+  "    @POST(\"pet\")\n" +
   "    fun addPet(@Body body: Pet): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -35,7 +35,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param status Status values that need to be considered for filter\n" +
   "     */\n" +
-  "    @GET(\"/pet/findByStatus\")\n" +
+  "    @GET(\"pet/findByStatus\")\n" +
   "    fun findPetsByStatus(@Query(\"status\") status: List<String>): Single<List<Pet>>\n" +
   "\n" +
   "    /**\n" +
@@ -43,7 +43,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param tags Tags to filter by\n" +
   "     */\n" +
-  "    @GET(\"/pet/findByTags\")\n" +
+  "    @GET(\"pet/findByTags\")\n" +
   "    fun findPetsByTags(@Query(\"tags\") tags: List<String>): Single<List<Pet>>\n" +
   "\n" +
   "    /**\n" +
@@ -51,7 +51,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param petId ID of pet to return\n" +
   "     */\n" +
-  "    @GET(\"/pet/{petId}\")\n" +
+  "    @GET(\"pet/{petId}\")\n" +
   "    fun getPetById(@Path(\"petId\") petId: Long): Single<Pet>\n" +
   "\n" +
   "    /**\n" +
@@ -61,7 +61,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     * @param name Updated name of the pet\n" +
   "     * @param status Updated status of the pet\n" +
   "     */\n" +
-  "    @POST(\"/pet/{petId}\")\n" +
+  "    @POST(\"pet/{petId}\")\n" +
   "    fun updatePetWithForm(@Path(\"petId\") petId: Long): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -69,7 +69,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param petId Pet id to delete\n" +
   "     */\n" +
-  "    @DELETE(\"/pet/{petId}\")\n" +
+  "    @DELETE(\"pet/{petId}\")\n" +
   "    fun deletePet(@Path(\"petId\") petId: Long): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -79,13 +79,13 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     * @param additionalMetadata Additional data to pass to server\n" +
   "     * @param file file to upload\n" +
   "     */\n" +
-  "    @POST(\"/pet/{petId}/uploadImage\")\n" +
+  "    @POST(\"pet/{petId}/uploadImage\")\n" +
   "    fun uploadFile(@Path(\"petId\") petId: Long): Single<ApiResponse>\n" +
   "\n" +
   "    /**\n" +
   "     * Returns pet inventories by status\n" +
   "     */\n" +
-  "    @GET(\"/store/inventory\")\n" +
+  "    @GET(\"store/inventory\")\n" +
   "    fun getInventory(): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -93,7 +93,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param body order placed for purchasing the pet\n" +
   "     */\n" +
-  "    @POST(\"/store/order\")\n" +
+  "    @POST(\"store/order\")\n" +
   "    fun placeOrder(@Body body: Order): Single<Order>\n" +
   "\n" +
   "    /**\n" +
@@ -101,7 +101,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param orderId ID of pet that needs to be fetched\n" +
   "     */\n" +
-  "    @GET(\"/store/order/{orderId}\")\n" +
+  "    @GET(\"store/order/{orderId}\")\n" +
   "    fun getOrderById(@Path(\"orderId\") orderId: Long): Single<Order>\n" +
   "\n" +
   "    /**\n" +
@@ -109,7 +109,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param orderId ID of the order that needs to be deleted\n" +
   "     */\n" +
-  "    @DELETE(\"/store/order/{orderId}\")\n" +
+  "    @DELETE(\"store/order/{orderId}\")\n" +
   "    fun deleteOrder(@Path(\"orderId\") orderId: Long): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -117,7 +117,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param body Created user object\n" +
   "     */\n" +
-  "    @POST(\"/user\")\n" +
+  "    @POST(\"user\")\n" +
   "    fun createUser(@Body body: User): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -125,7 +125,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param body List of user object\n" +
   "     */\n" +
-  "    @POST(\"/user/createWithArray\")\n" +
+  "    @POST(\"user/createWithArray\")\n" +
   "    fun createUsersWithArrayInput(@Body body: List<User>): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -133,7 +133,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param body List of user object\n" +
   "     */\n" +
-  "    @POST(\"/user/createWithList\")\n" +
+  "    @POST(\"user/createWithList\")\n" +
   "    fun createUsersWithListInput(@Body body: List<User>): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -142,13 +142,13 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     * @param username The user name for login\n" +
   "     * @param password The password for login in clear text\n" +
   "     */\n" +
-  "    @GET(\"/user/login\")\n" +
+  "    @GET(\"user/login\")\n" +
   "    fun loginUser(@Query(\"username\") username: String, @Query(\"password\") password: String): Completable\n" +
   "\n" +
   "    /**\n" +
   "     * Logs out current logged in user session\n" +
   "     */\n" +
-  "    @GET(\"/user/logout\")\n" +
+  "    @GET(\"user/logout\")\n" +
   "    fun logoutUser(): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -156,7 +156,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param username The name that needs to be fetched. Use user1 for testing.\n" +
   "     */\n" +
-  "    @GET(\"/user/{username}\")\n" +
+  "    @GET(\"user/{username}\")\n" +
   "    fun getUserByName(@Path(\"username\") username: String): Single<User>\n" +
   "\n" +
   "    /**\n" +
@@ -165,7 +165,7 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     * @param username name that need to be updated\n" +
   "     * @param body Updated user object\n" +
   "     */\n" +
-  "    @PUT(\"/user/{username}\")\n" +
+  "    @PUT(\"user/{username}\")\n" +
   "    fun updateUser(@Path(\"username\") username: String, @Body body: User): Completable\n" +
   "\n" +
   "    /**\n" +
@@ -173,6 +173,6 @@ const val PET_STORE_INTERFACE_MOCK = "package com.mycompany.mylibrary\n" +
   "     *\n" +
   "     * @param username The name that needs to be deleted\n" +
   "     */\n" +
-  "    @DELETE(\"/user/{username}\")\n" +
+  "    @DELETE(\"user/{username}\")\n" +
   "    fun deleteUser(@Path(\"username\") username: String): Completable\n" +
   "}\n"


### PR DESCRIPTION
Retrofit recommends that paths in the `@GET`, `@POST` etc do not start with a slash, because that clears any paths that the base URL might contain.

Example:
Correct URL: `http://example.com/folder/doSomething`
Retrofit Base URL: `http://example.com/folder/`

With the current implementation:
Method Annotation: `@GET("/doSomething")`
Generated URL: `http://example.com/doSomething`

With this change:
Method Annotation: `@GET("doSomething")`
Generated URL: `http://example.com/folder/doSomething`


This PR removes the beginning slash from the paths.